### PR TITLE
fix starcraft planet regex

### DIFF
--- a/src/test/java/org/thejavaguy/javafaker/StarCraftTest.java
+++ b/src/test/java/org/thejavaguy/javafaker/StarCraftTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 public class StarCraftTest extends AbstractFakerTest {
 
-  private final String noLeadingTrailingWhitespaceRegex = "^(?! )[A-Za-z0-9' ]*(?<! )$";
+  private final String noLeadingTrailingWhitespaceRegex = "^(?! )[A-Za-z0-9' -]*(?<! )$";
 
   @Test
   public void testUnit() {


### PR DESCRIPTION
## Summary

- fix StarCraftTest.testPlanet regex to allow hyphens (closes #44)

## Commits

```
15fe54f fix StarCraftTest.testPlanet regex to allow hyphens (closes #44)
```

## Test plan

- [ ] All tests pass: `./mvnw test`